### PR TITLE
Garrett a nullPixelFlag to OMS Chipper.   Setting true will enable

### DIFF
--- a/plugins/omar-oms-plugin/grails-app/controllers/omar/oms/ChipperController.groovy
+++ b/plugins/omar-oms-plugin/grails-app/controllers/omar/oms/ChipperController.groovy
@@ -187,7 +187,7 @@ class ChipperController {
 
     Is fixed to the value ortho
 
-*   **nullPixelFlip** 
+*   **nullPixelFlip**
 
     Flips null interior pixels to valid
 
@@ -262,7 +262,7 @@ class ChipperController {
           @ApiImplicitParam(name = 'images[0].file', value = 'filename', defaultValue = '', paramType = 'query', dataType = 'string', required=true),
           @ApiImplicitParam(name = 'images[0].entry', value = 'Image entry in the file', defaultValue = '', paramType = 'query', dataType = 'integer', required=false),
           @ApiImplicitParam(name = 'operation', value = '', defaultValue = 'none', allowableValues= "ortho", paramType = 'query', dataType = 'string', required=false),
-          @ApiImplicitParam(name = 'nullPixelFlip', value = 'Flip interior null pixels to valid', allowableValues="true,false", defaultValue="false", paramType = 'query', dataType = 'boolean', required=false),
+          @ApiImplicitParam(name = 'nullPixelFlip', value = 'Flip interior null pixels to valid', allowableValues="true,false", defaultValue="", paramType = 'query', dataType = 'boolean', required=false),
           @ApiImplicitParam(name = 'brightness', value = 'Brightness Operation',defaultValue="0.0", paramType = 'query', dataType = 'float', required=false),
           @ApiImplicitParam(name = 'contrast', value = 'Contrast Operation',defaultValue="1.0",  paramType = 'query', dataType = 'float', required=false),
           @ApiImplicitParam(name = 'sharpenMode', value = '', defaultValue = '', allowableValues="light,heavy",paramType = 'query', dataType = 'string', required=false),

--- a/plugins/omar-oms-plugin/src/main/groovy/omar/oms/ChipperCommand.groovy
+++ b/plugins/omar-oms-plugin/src/main/groovy/omar/oms/ChipperCommand.groovy
@@ -43,7 +43,7 @@ class ChipperCommand implements Validateable
    String      lutFile
    String      meters
    Boolean     northUp
-   Boolean     nullPixelFlip
+   Boolean     nullPixelFlip = true // HACK
    String      operation
    String      outputRadiometry
    Boolean     padThumbnail


### PR DESCRIPTION
the opacity for the interior pixels.