### PR TITLE
interim checkin

### DIFF
--- a/plugins/omar-oms-plugin/grails-app/controllers/omar/oms/ChipperController.groovy
+++ b/plugins/omar-oms-plugin/grails-app/controllers/omar/oms/ChipperController.groovy
@@ -323,4 +323,19 @@ class ChipperController {
           }
        }
    }
+
+   def executeChipper()
+   {
+     if ( request.method == 'POST' && request.JSON ) {
+       def initOps = request.JSON.inject([:]) { a, b ->
+          a[b?.key] = b?.value?.toString()
+          a
+       }
+       println initOps
+       render contentType: 'text/plain', text: ChipperUtil.executeChipper(initOps)
+     } else {
+       println 'ERROR'
+       render contentType: 'text/plain', text: false
+     }
+   }
 }


### PR DESCRIPTION
exposed executeChipper as a web service so it can be called directly.