### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=2.0.2
+buildVersion=2.0.3
 
 grailsVersion=4.0.1
 gorm.version=7.0.2.RELEASE


### PR DESCRIPTION
Updated buildVersion from 2.0.2 to buildVersion=2.0.3. This change support the omar-3pa release migration from tagged image 3pa-hotfix.